### PR TITLE
Add CLI parameter to inject the generated output type name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,30 @@
 PATH
   remote: .
   specs:
-    obfuskit (0.2.0)
+    obfuskit (0.2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     cgi (0.4.1)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     dotenv (2.8.1)
     erb (4.0.4)
       cgi (>= 0.3.3)
-    rake (13.1.0)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rake (13.2.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
 
 PLATFORMS
   arm64-darwin-22

--- a/README.md
+++ b/README.md
@@ -10,10 +10,29 @@ Install the latest version of the gem using:
 gem install obfuskit
 ```
 
+Call `obfuskit -h` for help.
+
+```bash
+Usage: obfuskit [options]
+
+Specific options:
+    -l, --language [LANGUAGE]        Output language (swift, kotlin). Kotlin requires a package parameter.
+    -k SECRET_1,SECRET_2,SECRET_3,   List of environment variable keys
+        --keys
+    -p, --package [PACKAGE]          Package name for Kotlin
+    -t, --type [TYPE]                Output type name. Defaults to `ObfusKit`
+
+Common options:
+    -h, --help                       Show this message
+    -v, --version                    Show version
+```
+
+### Swift
+
 To generate Swift code run the following command:
 
 ```sh
-obfuskit swift SECRET_1 SECRET_2 > generated.swift
+obfuskit -l swift -k SECRET_1,SECRET_2 > generated.swift
 ```
 
 It will will create the file `generated.swift` containing an obfuscated version of the environment variables `SECRET_1` and `SECRET_2`. 
@@ -34,10 +53,12 @@ enum ObfusKit {
 struct O { private let c: [UInt8]; private let l: Int; init(_ s: String) { self.init([UInt8](s.utf8)) }; init(_ c: [UInt8]) { self.c = c; l = c.count }; @inline(__always) func o(_ v: String) -> [UInt8] { [UInt8](v.utf8).enumerated().map { $0.element ^ c[$0.offset % l] } }; @inline(__always) func r(_ value: [UInt8]) -> String { String(bytes: value.enumerated().map { $0.element ^ c[$0.offset % l] }, encoding: .utf8) ?? "" } }
 ```
 
+### Kotlin 
+
 The same concept applies for the `kotlin` language using:
 
 ```sh
-obfuskit kotlin com.myapp.configuration.environment SECRET_1 SECRET_2 > generated.kt
+obfuskit -l kotlin -p com.myapp.configuration.environment -k SECRET_1,SECRET_2 > generated.kt
 ```
 It will create the Kotlin version `generated.kt`.
 

--- a/lib/obfuskit/generator.rb
+++ b/lib/obfuskit/generator.rb
@@ -10,12 +10,10 @@ module Obfuskit
 
   class Generator
 
-    def generate()
+    def generate
 
       parser = OptionsParser.new
       options = parser.parse(ARGV)
-
-      pp options
 
       Dotenv.load
 
@@ -24,11 +22,13 @@ module Obfuskit
         salt = SecureRandom.uuid.to_s.gsub("-", "")
         obfuscator = Obfuscator.new("_" + salt)
 
+        values = obfuscated_values_from_env(options.env_var_keys, obfuscator)
+
         if options.output_language == :swift
-          puts generate_swift(options.env_var_keys, obfuscator)
+          puts generate_with_template("swift", values, nil, options.output_type_name, obfuscator)
 
         elsif options.output_language == :kotlin && !options.package_name.nil?
-        puts generate_kotlin(options.env_var_keys, obfuscator)
+          puts generate_with_template("kotlin", values, options.package_name, options.output_type_name, obfuscator)
 
         else
         STDERR.puts parser.parse(%w[--help])
@@ -41,35 +41,21 @@ module Obfuskit
 
     private
 
-    def generate_swift(args, obfuscator)
-      values = obfuscated_values_from_env(args, obfuscator)
-      generate_with_template("swift", values, nil, obfuscator)
-    end
-
-    def generate_kotlin(args, obfuscator)
-      package = args.shift
-      if package == nil
-        STDERR.puts "No package name provided."
-      else
-        values = obfuscated_values_from_env(args, obfuscator)
-        generate_with_template("kotlin", values, package, obfuscator)
-      end
-    end
-
     def obfuscated_values_from_env(args, obfuscator)
-      args.map { |name|
+      args.map do |name|
         !ENV[name].nil? ? [name, obfuscator.obfuscate(ENV[name])] : nil
-      }.compact.to_h
+      end.compact.to_h
     end
 
-    def generate_with_template(template_name, values, package, obfuscator)
+    def generate_with_template(template_name, values, package, type_name, obfuscator)
       file = File.expand_path("templates/#{template_name}.erb", __dir__)
       template = ERB.new(File.read(file), trim_mode: "-")
       template.result_with_hash(
         values: values,
         package: package,
-        salt: obfuscator.salt
-      )
+        type_name: type_name,
+        salt: obfuscator.salt,
+        )
     end
 
   end

--- a/lib/obfuskit/options_parser.rb
+++ b/lib/obfuskit/options_parser.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+require 'optparse'
+
+class OptionsParser
+  class ScriptOptions
+
+    attr_accessor :output_language, :env_var_keys, :package_name
+
+    def initialize
+      self.output_language = nil
+      self.env_var_keys = []
+      self.package_name = nil
+    end
+
+    def define_options(parser)
+      parser.banner = "Usage: obfuskit [options]"
+      parser.separator ""
+      parser.separator "Specific options:"
+
+      # add additional options
+      output_language_option(parser)
+      env_var_keys_option(parser)
+      package_name_option(parser)
+
+      parser.separator ""
+      parser.separator "Common options:"
+      # No argument, shows at tail.  This will print an options summary.
+      # Try it and see!
+      parser.on_tail("-h", "--help", "Show this message") do
+        puts parser
+        exit
+      end
+
+      # Another typical switch to print the version.
+      parser.on_tail("-v", "--version", "Show version") do
+        puts Obfuskit::VERSION
+        exit
+      end
+
+    end
+
+    def output_language_option(parser)
+      parser.on("-l", "--language [LANGUAGE]", [:swift, :kotlin],
+                "Select output language (swift, kotlin). Kotlin requires a package parameter.") do |t|
+        self.output_language = t
+      end
+    end
+
+    def env_var_keys_option(parser)
+      parser.on("-k", "--keys SECRET_1,SECRET_2,SECRET_3", Array, "List of environment variable keys") do |list|
+        self.env_var_keys = list
+      end
+    end
+
+    def package_name_option(parser)
+      parser.on("-p", "--package [PACKAGE]", "Package name for Kotlin") do |package_name|
+        self.package_name = package_name
+      end
+    end
+  end
+
+  #
+  # Return a structure describing the options.
+  #
+  def parse(args)
+    # The options specified on the command line will be collected in
+    # *options*.
+
+    @options = ScriptOptions.new
+    @args = OptionParser.new do |parser|
+      @options.define_options(parser)
+      parser.parse!(args)
+    end
+    @options
+  end
+
+  attr_reader :parser, :options
+end  # class OptionsParser

--- a/lib/obfuskit/options_parser.rb
+++ b/lib/obfuskit/options_parser.rb
@@ -4,12 +4,13 @@ require 'optparse'
 class OptionsParser
   class ScriptOptions
 
-    attr_accessor :output_language, :env_var_keys, :package_name
+    attr_accessor :output_language, :env_var_keys, :package_name, :output_type_name
 
     def initialize
       self.output_language = nil
       self.env_var_keys = []
       self.package_name = nil
+      self.output_type_name = "ObfusKit"
     end
 
     def define_options(parser)
@@ -21,6 +22,7 @@ class OptionsParser
       output_language_option(parser)
       env_var_keys_option(parser)
       package_name_option(parser)
+      output_type_name_option(parser)
 
       parser.separator ""
       parser.separator "Common options:"
@@ -39,9 +41,11 @@ class OptionsParser
 
     end
 
+    private
+
     def output_language_option(parser)
       parser.on("-l", "--language [LANGUAGE]", [:swift, :kotlin],
-                "Select output language (swift, kotlin). Kotlin requires a package parameter.") do |t|
+                "Output language (swift, kotlin). Kotlin requires a package parameter.") do |t|
         self.output_language = t
       end
     end
@@ -53,8 +57,14 @@ class OptionsParser
     end
 
     def package_name_option(parser)
-      parser.on("-p", "--package [PACKAGE]", "Package name for Kotlin") do |package_name|
-        self.package_name = package_name
+      parser.on("-p", "--package [PACKAGE]", "Package name for Kotlin") do |value|
+        self.package_name = value
+      end
+    end
+
+    def output_type_name_option(parser)
+      parser.on("-t", "--type [TYPE]", "Output type name. Defaults to `ObfusKit`") do |value|
+        self.output_type_name = value
       end
     end
   end
@@ -67,7 +77,7 @@ class OptionsParser
     # *options*.
 
     @options = ScriptOptions.new
-    @args = OptionParser.new do |parser|
+    OptionParser.new do |parser|
       @options.define_options(parser)
       parser.parse!(args)
     end

--- a/lib/obfuskit/templates/kotlin.erb
+++ b/lib/obfuskit/templates/kotlin.erb
@@ -1,6 +1,6 @@
 package <%= package %>
 
-public object ObfusKit {
+public object <%= type_name %> {
   private val _o = O(<%= salt %>::class.java.simpleName)
   private class <%= salt %>
 

--- a/lib/obfuskit/templates/swift.erb
+++ b/lib/obfuskit/templates/swift.erb
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ObfusKit {
+public enum <%= type_name %> {
 <% values.each do |name, values| -%>
   public static let <%= name %>: String = _o.r([<%= values.map { |i| i.to_s }.join(', ') %>])
 <% end -%>

--- a/sig/obfuskit/generator.rbs
+++ b/sig/obfuskit/generator.rbs
@@ -3,9 +3,9 @@ module Obfuskit
     def generate: -> void
 
     private
-    def generate_kotlin: ([String], Obfuscator) -> String
-    def generate_swift: ([String], Obfuscator) -> String
+    def generate_kotlin: ([String], String, Obfuscator) -> String
+    def generate_swift: ([String], String, Obfuscator) -> String
     def obfuscated_values_from_env: ([String], Obfuscator) -> Hash[String, [Integer]]
-    def generate_with_template: (String, Hash[String, [Integer]], String?, Obfuscator) -> String
+    def generate_with_template: (String, Hash[String, [Integer]], String?, String, Obfuscator) -> String
   end
 end

--- a/sig/obfuskit/generator.rbs
+++ b/sig/obfuskit/generator.rbs
@@ -6,6 +6,6 @@ module Obfuskit
     def generate_kotlin: ([String], Obfuscator) -> String
     def generate_swift: ([String], Obfuscator) -> String
     def obfuscated_values_from_env: ([String], Obfuscator) -> Hash[String, [Integer]]
-    def generate_with_template: (String, Hash[String, [Integer]], String, Obfuscator) -> String
+    def generate_with_template: (String, Hash[String, [Integer]], String?, Obfuscator) -> String
   end
 end

--- a/sig/obfuskit/options_parser.rbs
+++ b/sig/obfuskit/options_parser.rbs
@@ -1,0 +1,4 @@
+class OptionsParser
+  attr_reader options: ScriptOptions
+  attr_reader parser: OptionsParser
+end

--- a/sig/obfuskit/options_parser.rbs
+++ b/sig/obfuskit/options_parser.rbs
@@ -1,4 +1,6 @@
 class OptionsParser
   attr_reader options: ScriptOptions
   attr_reader parser: OptionsParser
+
+  def parse: -> ScriptOptions
 end

--- a/sig/options_parser/script_options.rbs
+++ b/sig/options_parser/script_options.rbs
@@ -2,6 +2,15 @@ module OptionsParser
   class ScriptOptions
     attr_accessor env_var_keys: [String]
     attr_accessor output_language: String?
+    attr_accessor output_type_name: String
     attr_accessor package_name: String?
+
+    def define_options: -> void
+
+    private
+    def env_var_keys_option: -> OptionParser
+    def output_language_option: -> OptionParser
+    def output_type_name_option: -> OptionParser
+    def package_name_option: -> OptionParser
   end
 end

--- a/sig/options_parser/script_options.rbs
+++ b/sig/options_parser/script_options.rbs
@@ -1,0 +1,7 @@
+module OptionsParser
+  class ScriptOptions
+    attr_accessor env_var_keys: [String]
+    attr_accessor output_language: String?
+    attr_accessor package_name: String?
+  end
+end


### PR DESCRIPTION
This PR closes #13 

- This PR uses `optparse` to handle CLI options. 
- The CLI format changed from ~~`obfuskit swift SECRET_1 SECRET_2`~~ to `obfuskit -l swift -k SECRET_1,SECRET_2`
- Introducs `-t` option to overwrite the output type name from `ObfusKit` to something else
- Introduces `-l` for `:swift` or `:kotlin` language types
- Inroduces `-p` for `:kotlin` package name
- Introduces `-k` for Environment variable keys
