### PR TITLE
Add CLI parameter to inject an alternative .env file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ ObfusKit is a ruby script to generate obfuscated secrets for `Swift` and `Kotlin
 
 Install the latest version of the gem using:
 
-```
+```sh
 gem install obfuskit
 ```
 
 Call `obfuskit -h` for help.
 
-```bash
+```sh
 Usage: obfuskit [options]
 
 Specific options:
@@ -21,6 +21,7 @@ Specific options:
         --keys
     -p, --package [PACKAGE]          Package name for Kotlin
     -t, --type [TYPE]                Output type name. Defaults to `ObfusKit`
+    -e, --env [PATH]                 Path to an alternative .env file
 
 Common options:
     -h, --help                       Show this message
@@ -49,8 +50,7 @@ enum ObfusKit {
 	private class _3f3eccd2e5ea46b39738e5502bda6bef { }
 	private static let _o = O(String(describing: _3f3eccd2e5ea46b39738e5502bda6bef.self))
 }
-
-struct O { private let c: [UInt8]; private let l: Int; init(_ s: String) { self.init([UInt8](s.utf8)) }; init(_ c: [UInt8]) { self.c = c; l = c.count }; @inline(__always) func o(_ v: String) -> [UInt8] { [UInt8](v.utf8).enumerated().map { $0.element ^ c[$0.offset % l] } }; @inline(__always) func r(_ value: [UInt8]) -> String { String(bytes: value.enumerated().map { $0.element ^ c[$0.offset % l] }, encoding: .utf8) ?? "" } }
+// ...
 ```
 
 ### Kotlin 
@@ -72,9 +72,34 @@ object ObfusKit {
         val SECRET_1: String = _o.r(byteArrayOf(30, 116, 118, 115, 119, 119, 116))
         val SECRET_2: String = _o.r(byteArrayOf(24, 112, 112, 115, 113, 115, 114))
 }
+// ...
+```
 
-class O{private val a:ByteArray;private val b:Int;constructor(s:String){a=s.toByteArray(Charsets.UTF_8);b=a.size};fun o(v:String):ByteArray{val d=v.toByteArray(Charsets.UTF_8);return ByteArray(d.size){i->(d[i].toInt() xor a[i%b].toInt()).toByte()}};fun r(value:ByteArray):String{return String(ByteArray(value.size){i->(value[i].toInt() xor a[i%b].toInt()).toByte()},Charsets.UTF_8)}}
+## Customizations
 
+### The output type name
+
+The default generated type name in the target languate is `ObfusKit`. Customize this name with the `-t` option.
+
+```sh
+obfuskit -l swift -k SECRET_1,SECRET_2 -t Secrets > generated.swift
+```
+
+which will generate the Swift type `Secrets` instead of `ObfusKit`.
+
+```swift
+import Foundation
+
+enum Secrets {
+// ..
+```
+
+### Use a custom .env file location
+
+Use the `-e` option to define the path to a different `.env` file. e.g. if you want to reuse the the `fastlane/.env` file.
+
+```sh
+obfuskit -l swift -k SECRET_3,SECRET_4 -e fastlane/.env > generated.swift
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ObfusKit
-
-ObfusKit is a ruby script to generate obfuscated secrets for `Swift` and `Kotlin`.
+ObfusKit is a ruby script that generates obfuscated secrets for `Swift` and `Kotlin`.
 
 ## Installation and usage
 
@@ -31,12 +30,7 @@ Common options:
 ### Swift
 
 To generate Swift code run the following command:
-
-```sh
-obfuskit -l swift -k SECRET_1,SECRET_2 > generated.swift
-```
-
-It will will create the file `generated.swift` containing an obfuscated version of the environment variables `SECRET_1` and `SECRET_2`. 
+It will create the file `generated.swift` containing an obfuscated version of the environment variables `SECRET_1` and `SECRET_2`. 
 This file should be excluded from the git repository and generated at build time. 
 The obfuscation salt is regenerated for each run.
 
@@ -79,13 +73,8 @@ object ObfusKit {
 
 ### The output type name
 
-The default generated type name in the target languate is `ObfusKit`. Customize this name with the `-t` option.
-
-```sh
-obfuskit -l swift -k SECRET_1,SECRET_2 -t Secrets > generated.swift
-```
-
-which will generate the Swift type `Secrets` instead of `ObfusKit`.
+The default generated type name in the target language is `ObfusKit``. Customize this name with the `-t` option.
+Which will generate the Swift type `Secrets` instead of `ObfusKit`.
 
 ```swift
 import Foundation
@@ -96,7 +85,7 @@ enum Secrets {
 
 ### Use a custom .env file location
 
-Use the `-e` option to define the path to a different `.env` file. e.g. if you want to reuse the the `fastlane/.env` file.
+Use the `-e` option to define the path to a different `.env` file, e.g. if you want to reuse the `fastlane/.env` file.
 
 ```sh
 obfuskit -l swift -k SECRET_3,SECRET_4 -e fastlane/.env > generated.swift

--- a/lib/obfuskit/generator.rb
+++ b/lib/obfuskit/generator.rb
@@ -15,7 +15,7 @@ module Obfuskit
       parser = OptionsParser.new
       options = parser.parse(ARGV)
 
-      Dotenv.load
+      Dotenv.load(options.dot_env_file_path)
 
       if !options.output_language.nil? && options.env_var_keys.length.positive?
 

--- a/lib/obfuskit/options_parser.rb
+++ b/lib/obfuskit/options_parser.rb
@@ -4,13 +4,14 @@ require 'optparse'
 class OptionsParser
   class ScriptOptions
 
-    attr_accessor :output_language, :env_var_keys, :package_name, :output_type_name
+    attr_accessor :output_language, :env_var_keys, :package_name, :output_type_name, :dot_env_file_path
 
     def initialize
       self.output_language = nil
       self.env_var_keys = []
       self.package_name = nil
       self.output_type_name = "ObfusKit"
+      self.dot_env_file_path = ".env"
     end
 
     def define_options(parser)
@@ -23,6 +24,7 @@ class OptionsParser
       env_var_keys_option(parser)
       package_name_option(parser)
       output_type_name_option(parser)
+      dot_env_file_path_options(parser)
 
       parser.separator ""
       parser.separator "Common options:"
@@ -65,6 +67,12 @@ class OptionsParser
     def output_type_name_option(parser)
       parser.on("-t", "--type [TYPE]", "Output type name. Defaults to `ObfusKit`") do |value|
         self.output_type_name = value
+      end
+    end
+
+    def dot_env_file_path_options(parser)
+      parser.on("-e", "--env [PATH]", "Path to an alternative .env file") do |value|
+        self.dot_env_file_path = value
       end
     end
   end

--- a/sig/options_parser/script_options.rbs
+++ b/sig/options_parser/script_options.rbs
@@ -1,5 +1,7 @@
 module OptionsParser
   class ScriptOptions
+    attr_accessor dot_env_file_path: String
+    attr_accessor dot_env_file_paths: [String]
     attr_accessor env_var_keys: [String]
     attr_accessor output_language: String?
     attr_accessor output_type_name: String
@@ -8,6 +10,8 @@ module OptionsParser
     def define_options: -> void
 
     private
+
+    def dot_env_file_path_options: -> OptionParser
     def env_var_keys_option: -> OptionParser
     def output_language_option: -> OptionParser
     def output_type_name_option: -> OptionParser


### PR DESCRIPTION
This PR closes #14 

The PR allows the customization of the `.env` file by declaring its location with the `-e` parameter.