### PR TITLE
Add --keep-annotation to CLI and Kotlin template

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    obfuskit (0.2.1)
+    obfuskit (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -74,17 +74,14 @@ object ObfusKit {
 // ...
 ```
 
-## Customizations
+#### Android Code shrinking and Obfuscation
+Proguard/R8 changes class names and method names. This will break revealing secrets at run time.
+To prevent this, add the according rules to your `proguard-rules.pro` file or use the `--keep-annotation` parameter to inject a custom annotation like `@androidx.annotation.Keep` into the generated code.
 
-### The output type name
+For example:
 
-The default generated type name in the target language is `ObfusKit`. Customize this name with the `-t` option to generate the Swift type `Secrets` instead of `ObfusKit`.
-
-```swift
-import Foundation
-
-enum Secrets {
-// ..
+```sh
+obfuskit -l kotlin -p com.myapp.configuration.environment -k SECRET_1,SECRET_2 --keep-annotation @androidx.annotation.Keep > generated.kt
 ```
 
 ### Use a custom .env file location

--- a/lib/obfuskit/generator.rb
+++ b/lib/obfuskit/generator.rb
@@ -25,10 +25,10 @@ module Obfuskit
         values = obfuscated_values_from_env(options.env_var_keys, obfuscator)
 
         if options.output_language == :swift
-          puts generate_with_template("swift", values, nil, options.output_type_name, obfuscator)
+          puts generate_with_template("swift", values, nil, options.output_type_name, obfuscator, options.keep_annotation)
 
         elsif options.output_language == :kotlin && !options.package_name.nil?
-          puts generate_with_template("kotlin", values, options.package_name, options.output_type_name, obfuscator)
+          puts generate_with_template("kotlin", values, options.package_name, options.output_type_name, obfuscator, options.keep_annotation)
 
         else
         STDERR.puts parser.parse(%w[--help])
@@ -47,7 +47,7 @@ module Obfuskit
       end.compact.to_h
     end
 
-    def generate_with_template(template_name, values, package, type_name, obfuscator)
+    def generate_with_template(template_name, values, package, type_name, obfuscator, keep_annotation)
       file = File.expand_path("templates/#{template_name}.erb", __dir__)
       template = ERB.new(File.read(file), trim_mode: "-")
       template.result_with_hash(
@@ -55,6 +55,7 @@ module Obfuskit
         package: package,
         type_name: type_name,
         salt: obfuscator.salt,
+        keep_annotation: keep_annotation
         )
     end
 

--- a/lib/obfuskit/options_parser.rb
+++ b/lib/obfuskit/options_parser.rb
@@ -4,7 +4,7 @@ require 'optparse'
 class OptionsParser
   class ScriptOptions
 
-    attr_accessor :output_language, :env_var_keys, :package_name, :output_type_name, :dot_env_file_path
+    attr_accessor :output_language, :env_var_keys, :package_name, :output_type_name, :dot_env_file_path, :keep_annotation
 
     def initialize
       self.output_language = nil
@@ -12,6 +12,7 @@ class OptionsParser
       self.package_name = nil
       self.output_type_name = "ObfusKit"
       self.dot_env_file_path = ".env"
+      self.keep_annotation = nil
     end
 
     def define_options(parser)
@@ -25,6 +26,7 @@ class OptionsParser
       package_name_option(parser)
       output_type_name_option(parser)
       dot_env_file_path_options(parser)
+      keep_annotation_options(parser)
 
       parser.separator ""
       parser.separator "Common options:"
@@ -73,6 +75,13 @@ class OptionsParser
     def dot_env_file_path_options(parser)
       parser.on("-e", "--env [PATH]", "Path to an alternative .env file") do |value|
         self.dot_env_file_path = value
+      end
+    end
+
+    def keep_annotation_options(parser)
+      parser.on("--keep-annotation [Annotation]", "Annotation to prevent key class obfuscation. e.g. @androidx.annotation.Kee
+") do |value|
+        self.keep_annotation = value
       end
     end
   end

--- a/lib/obfuskit/templates/kotlin.erb
+++ b/lib/obfuskit/templates/kotlin.erb
@@ -2,6 +2,7 @@ package <%= package %>
 
 public object <%= type_name %> {
   private val _o = O(<%= salt %>::class.java.simpleName)
+  <%= keep_annotation unless keep_annotation.nil? %>
   private class <%= salt %>
 
 <% values.each do |name, values| -%>

--- a/sig/options_parser/script_options.rbs
+++ b/sig/options_parser/script_options.rbs
@@ -3,6 +3,7 @@ module OptionsParser
     attr_accessor dot_env_file_path: String
     attr_accessor dot_env_file_paths: [String]
     attr_accessor env_var_keys: [String]
+    attr_accessor keep_annotation: String?
     attr_accessor output_language: String?
     attr_accessor output_type_name: String
     attr_accessor package_name: String?
@@ -13,6 +14,7 @@ module OptionsParser
 
     def dot_env_file_path_options: -> OptionParser
     def env_var_keys_option: -> OptionParser
+    def keep_annotation_options: -> OptionParser
     def output_language_option: -> OptionParser
     def output_type_name_option: -> OptionParser
     def package_name_option: -> OptionParser


### PR DESCRIPTION
This PR closes #17 

Proguard/R8 changes class names and method names. This will break revealing secrets at run time.
To prevent this, add the according rules to your `proguard-rules.pro` file or use the `--keep-annotation` parameter to inject a custom annotation like `@androidx.annotation.Keep` into the generated code.

For example:

```sh
obfuskit -l kotlin -p com.myapp.configuration.environment -k SECRET_1,SECRET_2 --keep-annotation @androidx.annotation.Keep > generated.kt
```